### PR TITLE
bug fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ graphify-out/
 src/main/graphify-out/
 .graphify*
 .agents*
+debug_crash.py
 env/
 venv/
 

--- a/src/main/python/utils/Graphics.py
+++ b/src/main/python/utils/Graphics.py
@@ -710,8 +710,9 @@ class NodeItem(QtWidgets.QGraphicsItem):
         # self.dock_widget.setFixedHeight(640)
         self.dock_widget.setMinimumSize(280, 400)
         self.dock_widget.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
-        self.dock_widget.DockWidgetFeature(QDockWidget.AllDockWidgetFeatures)
-        self.main_window.addDockWidget(Qt.LeftDockWidgetArea, self.dock_widget)
+        self.dock_widget.setFeatures(QDockWidget.AllDockWidgetFeatures)
+        if self.main_window is not None:
+            self.main_window.addDockWidget(Qt.LeftDockWidgetArea, self.dock_widget)
 
         # ✅ Update parameters safely (skip MaterialStream)
         if self.dock_widget.obj.type != 'MaterialStream':
@@ -1122,10 +1123,10 @@ class NodeItem(QtWidgets.QGraphicsItem):
         
 def findMainWindow(self):
     '''
-        Global function to find the (open) QMainWindow in application
+        Safely find the QMainWindow by navigating up the widget hierarchy from the graphicsView.
     ''' 
-    app = QApplication.instance()
-    for widget in app.topLevelWidgets():
-        if isinstance(widget, QMainWindow):
-            return widget
-    return None             
+    if hasattr(self, 'graphicsView') and self.graphicsView is not None:
+        return self.graphicsView.window()
+    elif hasattr(self, 'container') and hasattr(self.container, 'graphicsView') and self.container.graphicsView is not None:
+        return self.container.graphicsView.window()
+    return None


### PR DESCRIPTION
1. **Dock Widget Initialization**

- Replaced DockWidgetFeature call with setFeatures(QDockWidget.AllDockWidgetFeatures) for proper feature assignment. 
- Added a safety check to ensure main_window is not None before adding the dock widget, preventing potential crashes.


2. **Main Window Detection**

- Updated findMainWindow to safely navigate the widget hierarchy:

> i.First checks if graphicsView exists and returns its parent window.
> ii.Falls back to container.graphicsView if available.
> iii.Returns None otherwise.

- This avoids reliance on global QApplication.instance() scanning and ensures more reliable detection.