### PR TITLE
Compound Selector Restored, Selected Compounds Panel Hidden by Default, removed the default no. of compounds selected with a drop-down selector

### DIFF
--- a/src/main/python/DockWidgets/DockWidgetMixer.py
+++ b/src/main/python/DockWidgets/DockWidgetMixer.py
@@ -34,17 +34,41 @@ class DockWidgetMixer(QDockWidget,ui_dialog):
     def input_params_list(self):
         try:        
             self.l1.setText(self.obj.variables['NI']['name']+":")
-            self.le1.setText(str(self.obj.variables['NI']['value']))
+
+            # Replace the line-edit (le1) with a combo box for NI (2–6)
+            self.ni_combo = QComboBox()
+            for v in range(2, 7):
+                self.ni_combo.addItem(str(v))
+            current_ni = self.obj.variables['NI']['value']
+            self.ni_combo.setCurrentText(str(current_ni))
+
+            # Swap le1 out of the gridLayout and put ni_combo in its place
+            # The grid layout is named 'gridLayout' in the .ui file
+            grid = self.gridLayout
+            # Find le1's position in the grid (row=0, col=2 per the .ui)
+            idx = grid.indexOf(self.le1)
+            if idx >= 0:
+                row, col, rowspan, colspan = grid.getItemPosition(idx)
+                grid.removeWidget(self.le1)
+                self.le1.hide()
+                self.le1.setParent(None)
+                grid.addWidget(self.ni_combo, row, col)
+            else:
+                # Fallback: just hide le1 and add combo at known position
+                self.le1.hide()
+                self.le1.setParent(None)
+                grid.addWidget(self.ni_combo, 0, 2)
+
             self.u1.setText(self.obj.variables['NI']['unit'])
             for i in self.obj.Pout_modes:
                 self.cb2.addItem(str(i))
             self.cb2.setCurrentText(self.obj.variables['outPress']['value'])
 
             self.l2.setText(self.obj.variables['outPress']['name']+":")
-            self.input_dict = [self.le1, self.cb2]
+            self.input_dict = [self.ni_combo, self.cb2]
  
         except Exception as e:
-            print(f"[UI] Submit failed for {self.name}: {e}")
+            print(f"[UI] input_params_list failed for {self.name}: {e}")
             print(e)
     
     def show_error(self):
@@ -53,9 +77,18 @@ class DockWidgetMixer(QDockWidget,ui_dialog):
     def param(self):
         try:
             self.dict={}
-            self.dict = [int(self.input_dict[0].text()), self.input_dict[1].currentText()]
+            new_ni = int(self.input_dict[0].currentText())
+            self.dict = [new_ni, self.input_dict[1].currentText()]
             self.obj.param_setter(self.dict)
             print(f"[UI] Submit successful for {self.name}")
+
+            # Refresh input ports 
+            from python.utils.Graphics import lst
+            for node in lst:
+                if node.obj is self.obj:
+                    node.update_input_ports(new_ni)
+                    break
+
             if(self.isVisible()):
                  #added try block to safely handle the errors
                 try:

--- a/src/main/python/DockWidgets/DockWidgetSplitter.py
+++ b/src/main/python/DockWidgets/DockWidgetSplitter.py
@@ -33,7 +33,28 @@ class DockWidgetSplitter(QDockWidget,ui_dialog):
     def input_params_list(self):
         try:        
             self.l1.setText(self.obj.variables['No']['name']+":")
-            self.le1.setText(str(self.obj.variables['No']['value']))
+
+            # Replace le1 with a combo box for No. of Output (2–6)
+            self.no_combo = QComboBox()
+            for v in range(2, 7):
+                self.no_combo.addItem(str(v))
+            current_no = self.obj.variables['No']['value']
+            self.no_combo.setCurrentText(str(current_no))
+
+            # Swap le1 out of gridLayout and put no_combo in its place
+            grid = self.gridLayout
+            idx = grid.indexOf(self.le1)
+            if idx >= 0:
+                row, col, rowspan, colspan = grid.getItemPosition(idx)
+                grid.removeWidget(self.le1)
+                self.le1.hide()
+                self.le1.setParent(None)
+                grid.addWidget(self.no_combo, row, col)
+            else:
+                self.le1.hide()
+                self.le1.setParent(None)
+                grid.addWidget(self.no_combo, 0, 2)
+
             self.u1.setText(self.obj.variables['No']['unit'])
 
             self.l2.setText(self.obj.variables['CalcType']['name'] + ":")
@@ -49,10 +70,10 @@ class DockWidgetSplitter(QDockWidget,ui_dialog):
             self.u4.setText(str(self.obj.variables['SpecVal_s']['unit']))
             self.cb2.currentIndexChanged.connect(self.fun)
 
-            self.input_dict = [self.le1, self.cb2, self.le3, self.le4]
+            self.input_dict = [self.no_combo, self.cb2, self.le3, self.le4]
  
         except Exception as e:
-            print(f"[UI] Submit failed for {self.name}: {e}")
+            print(f"[UI] input_params_list failed for {self.name}: {e}")
             print(e)
 
     def fun(self):
@@ -72,9 +93,18 @@ class DockWidgetSplitter(QDockWidget,ui_dialog):
     def param(self):
         try:
             self.dict={}
-            self.dict = [int(self.input_dict[0].text()),self.input_dict[1].currentText(), float(self.input_dict[2].text()), float(self.input_dict[3].text())]
+            new_no = int(self.input_dict[0].currentText())
+            self.dict = [new_no, self.input_dict[1].currentText(), float(self.input_dict[2].text()), float(self.input_dict[3].text())]
             self.obj.param_setter(self.dict)
             print(f"[UI] Submit successful for {self.name}")
+
+            # Refresh output ports 
+            from python.utils.Graphics import lst
+            for node in lst:
+                if node.obj is self.obj:
+                    node.update_output_ports(new_no)
+                    break
+
             if(self.isVisible()):
                 #added try block to safely handle the errors
                 try:

--- a/src/main/python/Landing_page.py
+++ b/src/main/python/Landing_page.py
@@ -263,8 +263,7 @@ class LandingPage(QWidget):
             self.hide()
 
             # Ensure compound selector is visible
-            # unncomment the below line to show the compound selector
-            # QTimer.singleShot(100, lambda: self.show_compound_selector())
+            QTimer.singleShot(100, lambda: self.show_compound_selector())
 
         finally:
             self.reset_cursor()
@@ -280,13 +279,13 @@ class LandingPage(QWidget):
         comp_window.activateWindow()
 
         # === Show Intro Page overlay (same size and position) ===
-        self.intro_page = IntroPage(self.launch_compound_selector, self.cancel_intro)
-        self.intro_page.resize(comp_window.size())
-        self.intro_page.move(comp_window.pos())
-        self.intro_page.setWindowFlag(Qt.WindowStaysOnTopHint)
-        self.intro_page.setWindowModality(Qt.ApplicationModal)
-        self.intro_page.show()
-        self.intro_page.raise_()
+        # self.intro_page = IntroPage(self.launch_compound_selector, self.cancel_intro)
+        # self.intro_page.resize(comp_window.size())
+        # self.intro_page.move(comp_window.pos())
+        # self.intro_page.setWindowFlag(Qt.WindowStaysOnTopHint)
+        # self.intro_page.setWindowModality(Qt.ApplicationModal)
+        # self.intro_page.show()
+        # self.intro_page.raise_()
 
     def launch_compound_selector(self):
         """When user clicks Next on IntroPage"""

--- a/src/main/python/mainApp.py
+++ b/src/main/python/mainApp.py
@@ -184,6 +184,7 @@ class MainApp(QMainWindow,ui):
         self.selectedElementsDock.setWidget(sel_dock_container)
 
         self.addDockWidget(Qt.LeftDockWidgetArea, self.selectedElementsDock)
+        self.selectedElementsDock.hide()
 
         self.dockWidget.setFeatures(QDockWidget.DockWidgetFloatable |
                                     QDockWidget.DockWidgetMovable |
@@ -221,10 +222,9 @@ class MainApp(QMainWindow,ui):
         self.menu_bar()
 
         self.button_handler()
-        # uncomment the below three lines to show the compound selector
-        # self.comp.show()
-        # self.comp.raise_()          # Bring to front
-        # self.comp.activateWindow()
+        self.comp.show()
+        self.comp.raise_()          # Bring to front
+        self.comp.activateWindow()
 
         from python.utils.undo_manager import clean_file, push
         clean_file('Undo')
@@ -286,7 +286,7 @@ class MainApp(QMainWindow,ui):
         # View : Selected Compounds 
         self.actionViewSelectedElements = QAction("Selected Compounds", self)
         self.actionViewSelectedElements.setCheckable(True)
-        self.actionViewSelectedElements.setChecked(True)
+        self.actionViewSelectedElements.setChecked(False)
         self.actionViewSelectedElements.triggered.connect(self.toggle_selected_elements_view)
         self.menuView.addAction(self.actionViewSelectedElements)
 
@@ -599,10 +599,9 @@ class MainApp(QMainWindow,ui):
     def new_project(self):
         self.new()  # reset everything
         # Show compound selector properly
-        # uncomment the below three lines to show the compound selector
-        # self.comp.show()
-        # self.comp.raise_()
-        # self.comp.activateWindow()
+        self.comp.show()
+        self.comp.raise_()
+        self.comp.activateWindow()
 
 
     '''

--- a/src/main/python/utils/Graphics.py
+++ b/src/main/python/utils/Graphics.py
@@ -762,16 +762,11 @@ class NodeItem(QtWidgets.QGraphicsItem):
             self.obj.no_of_inputs = self.nin
             self.obj.variables['NI']['value'] = self.nin
 
-        # ✅ Distillation Column: ask number of input(s)
+        # ✅ Distillation Column: use default 1 input for new components (no prompt)
         elif self.obj.type == 'DistillationColumn' and not getattr(self.obj, "saved", False):
-            combo_values = list(map(str, range(1, 9)))
-            text, self.ok = QInputDialog.getItem(
-                self.container.graphicsView, 'DistillationColumn', 'Select number of input(s):', combo_values, False
-            )
-            if self.ok:
-                self.nin = int(text)
-                self.obj.no_of_inputs = self.nin
-                self.obj.variables['Ni']['value'] = self.nin
+            self.nin = 1
+            self.obj.no_of_inputs = self.nin
+            self.obj.variables['Ni']['value'] = self.nin
 
         # ✅ Default input/output counts
         self.nin = getattr(self.obj, "no_of_inputs", 0)
@@ -1146,11 +1141,143 @@ class NodeItem(QtWidgets.QGraphicsItem):
             self.obj.set_pos(self.current_pos)
 
 
+    def update_input_ports(self, new_count):
+        """Dynamically adjust the number of input sockets for this node (e.g. Mixer)."""
+        old_count = len(self.input)
+        if new_count == old_count:
+            return
+
+        self.prepareGeometryChange()
+
+        # Remove excess sockets from the end
+        while len(self.input) > new_count:
+            socket = self.input.pop()
+            # Remove any connected lines from the scene
+            for line in list(socket.in_lines):
+                # Clean up the source side
+                if hasattr(line, 'source') and line.source is not None:
+                    if line in line.source.out_lines:
+                        line.source.out_lines.remove(line)
+                    # Remove logical connection on the source object
+                    try:
+                        line.source.parent.obj.remove_connection(0, line.source.id)
+                    except Exception as e:
+                        print(f"[DEBUG] update_input_ports: source cleanup error: {e}")
+                # Remove logical connection on this object
+                try:
+                    self.obj.remove_connection(1, socket.id)
+                except Exception as e:
+                    print(f"[DEBUG] update_input_ports: target cleanup error: {e}")
+                if self.scene() is not None:
+                    self.scene().removeItem(line)
+            socket.in_lines.clear()
+            if self.scene() is not None:
+                self.scene().removeItem(socket)
+
+        # Add new sockets if needed
+        while len(self.input) < new_count:
+            idx = len(self.input) + 1
+            socket = NodeSocket(
+                QtCore.QRect(
+                    int(-6.5),
+                    int(self.rect.height() * idx / (new_count + 1) - 6),
+                    12, 12
+                ),
+                self, 'in', idx
+            )
+            self.input.append(socket)
+
+        # Reposition all input sockets evenly
+        for i, socket in enumerate(self.input):
+            idx = i + 1
+            socket.prepareGeometryChange()
+            socket.rect = QtCore.QRectF(
+                -6.5,
+                self.rect.height() * idx / (new_count + 1) - 6,
+                12, 12
+            )
+            socket.id = idx
+            socket.update()
+
+        self.nin = new_count
+        self._orig_input_rects = [QtCore.QRectF(s.rect) for s in self.input]
+        self._update_connected_lines()
+        self.update()
+        print(f"[DEBUG] update_input_ports: {old_count} → {new_count} ports")
+
+    def update_output_ports(self, new_count):
+        """Dynamically adjust the number of output sockets for this node (e.g. Splitter)."""
+        old_count = len(self.output)
+        if new_count == old_count:
+            return
+
+        self.prepareGeometryChange()
+
+        # Remove excess sockets from the end
+        while len(self.output) > new_count:
+            socket = self.output.pop()
+            # Remove any connected lines from the scene
+            for line in list(socket.out_lines):
+                # Clean up the target side
+                if hasattr(line, 'target') and line.target is not None:
+                    if line in line.target.in_lines:
+                        line.target.in_lines.remove(line)
+                    # Remove logical connection on the target object
+                    try:
+                        line.target.parent.obj.remove_connection(1, line.target.id)
+                    except Exception as e:
+                        print(f"[DEBUG] update_output_ports: target cleanup error: {e}")
+                # Remove logical connection on this object
+                try:
+                    self.obj.remove_connection(0, socket.id)
+                except Exception as e:
+                    print(f"[DEBUG] update_output_ports: source cleanup error: {e}")
+                if self.scene() is not None:
+                    self.scene().removeItem(line)
+            socket.out_lines.clear()
+            if self.scene() is not None:
+                self.scene().removeItem(socket)
+
+        # Add new sockets if needed
+        while len(self.output) < new_count:
+            idx = len(self.output) + 1
+            socket = NodeSocket(
+                QtCore.QRect(
+                    int(self.rect.width() - 6.5),
+                    int(self.rect.height() * idx / (new_count + 1) - 6),
+                    12, 12
+                ),
+                self, 'op', idx
+            )
+            self.output.append(socket)
+
+        # Reposition all output sockets evenly
+        for i, socket in enumerate(self.output):
+            idx = i + 1
+            socket.prepareGeometryChange()
+            socket.rect = QtCore.QRectF(
+                self.rect.width() - 6.5,
+                self.rect.height() * idx / (new_count + 1) - 6,
+                12, 12
+            )
+            socket.id = idx
+            socket.update()
+
+        self.nop = new_count
+        self._orig_output_rects = [QtCore.QRectF(s.rect) for s in self.output]
+        self._update_connected_lines()
+        self.update()
+        print(f"[DEBUG] update_output_ports: {old_count} → {new_count} ports")
+
                 
     def mouseDoubleClickEvent(self, event):
 
         self.graphicsView.horizontalScrollBarVal = self.graphicsView.horizontalScrollBar().value()
         self.graphicsView.setInteractive(False)
+        # Purge any destroyed widgets from the stack before accessing
+        import sip
+        while stack and sip.isdeleted(stack[-1]):
+            stack.pop()
         if len(stack):
             stack[-1].hide()
         self.dock_widget.show()

--- a/src/main/python/utils/UnitOperations.py
+++ b/src/main/python/utils/UnitOperations.py
@@ -660,6 +660,7 @@ class Splitter(UnitOperation):
     def param_setter(self,params):
         #print("param_setter ", params)
         self.variables['No']['value'] = int(params[0])
+        self.no_of_outputs = int(params[0])
         self.variables['CalcType']['value'] = params[1]
         self.variables['SpecVal_s']['value'] = [float(params[2]), float(params[3])]
         if self.variables['CalcType']['value'] == 'Molar_Flow':
@@ -691,6 +692,7 @@ class Mixer(UnitOperation):
 
     def param_setter(self, params):
         self.variables['NI']['value'] = int(params[0])
+        self.no_of_inputs = int(params[0])
         self.variables['outPress']['value'] = params[1]
         
 class Heater(UnitOperation):

--- a/src/main/ui/DockWidgets/DockWidgetMixer.ui
+++ b/src/main/ui/DockWidgets/DockWidgetMixer.ui
@@ -91,7 +91,7 @@
       <item row="0" column="2">
        <widget class="QLineEdit" name="le1">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/src/main/ui/DockWidgets/DockWidgetSplitter.ui
+++ b/src/main/ui/DockWidgets/DockWidgetSplitter.ui
@@ -78,7 +78,7 @@
       <item row="0" column="2">
        <widget class="QLineEdit" name="le1">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">


### PR DESCRIPTION
**1. Compound Selector Restored:** reverted the previous commit so the compound selector now automatically opens at startup.
**2. Wizard Hidden:** commented out the logic in Landing_page.py that overlays the wizard on top of the compound selector. Now, only the compound selector itself will appear on startup (Ln. 282 - 288).
**3. Selected Compounds Panel Hidden by Default:** In mainApp.py, the selectedElementsDock during initialization and unchecked its corresponding action (actionViewSelectedElements). The panel is now hidden by default but can still be toggled on/off anytime from the "View" menu.
**4. Removed the default two compounds selected:** the mixer and splitter are now configurable after double clicking, a window appears.
**5. Drop down feature in config:** added drop down selector (combo box) to select number of the compounds to be used in splitter and mixer. 
**6. Realtime node creation on the canvas:** as we select the number of compounds, the mixer and splitter generates new nodes according to the selection done.
**7. Logs in debug console:** 
`[UI] input_params_list failed for.......`


<img width="1920" height="1080" alt="Screenshot 2026-06-04 231351" src="https://github.com/user-attachments/assets/75623d13-6978-468d-9fec-c9dec088ac0a" />
