### PR TITLE
Basicfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 *_init.xml
 
 # Generated Modelica files
+src/main/Simulator/Simulator/testFlowsheet.mos
 Flowsheet.mo
 simulateEQN.mos
 FlowsheetSEQ.csv__pycache__/

--- a/src/main/Simulator/Simulator/Streams/MaterialStream.mo
+++ b/src/main/Simulator/Simulator/Streams/MaterialStream.mo
@@ -11,23 +11,23 @@ model MaterialStream "Model representing Material Stream"
   Real T(unit = "K", start = Tg) "Temperature";
   Real Pbubl(unit = "Pa", min = 0, start = Pmin) "Bubble point pressure";
   Real Pdew(unit = "Pa", min = 0, start = Pmax) "dew point pressure";
-  Real xliq(unit = "-", start = xliqg, min = 0, max = 1) "Liquid Phase mole fraction";
-  Real xvap(unit = "-", start = xvapg, min = 0, max = 1) "Vapor Phase mole fraction";
-  Real xmliq(unit = "-", start = xliqg, min = 0, max = 1) "Liquid Phase mass fraction";
-  Real xmvap(unit = "-",start =xvapg, min = 0, max = 1) "Vapor Phase Mass fraction";
+  Real xliq(unit = "1", start = xliqg, min = 0, max = 1) "Liquid Phase mole fraction";
+  Real xvap(unit = "1", start = xvapg, min = 0, max = 1) "Vapor Phase mole fraction";
+  Real xmliq(unit = "1", start = xliqg, min = 0, max = 1) "Liquid Phase mass fraction";
+  Real xmvap(unit = "1",start =xvapg, min = 0, max = 1) "Vapor Phase Mass fraction";
   Real F_p[3](each unit = "mol/s", each min = 0, start={Fg,Fliqg,Fvapg}) "Total molar flow in phase";
   Real Fm_p[3](each unit = "kg/s", each min = 0, each start = Fg) "Total mass flow in phase";
-  Real MW_p[3](each unit = "-", each start = 0, each min = 0) "Average Molecular weight in phase";
-  Real x_pc[3, Nc](each unit = "-", each min = 0, each max = 1, start={xguess,xg,yg}) "Component mole fraction in phase";
-  Real xm_pc[3, Nc](each unit ="-", start={xguess,xg,yg}, each min = 0, each max = 1) "Component mass fraction in phase";
+  Real MW_p[3](each unit = "1", each start = 0, each min = 0) "Average Molecular weight in phase";
+  Real x_pc[3, Nc](each unit = "1", each min = 0, each max = 1, start={xguess,xg,yg}) "Component mole fraction in phase";
+  Real xm_pc[3, Nc](each unit = "1", start={xguess,xg,yg}, each min = 0, each max = 1) "Component mass fraction in phase";
   Real F_pc[3, Nc](each unit = "mol/s", each start = Fg, each min = 0) "Component molar flow in phase";
   Real Fm_pc[3, Nc](each unit = "kg/s", each min = 0, each start = Fg) "Component mass flow in phase";
-  Real Cp_p[3](each unit = "kJ/[kmol.K]",start={Hmixg,Hliqg,Hvapg}) "Phase molar specific heat";
-  Real Cp_pc[3, Nc](each unit = "kJ/[kmol.K]") "Component molar specific heat in phase";
+  Real Cp_p[3](each unit = "kJ/(kmol.K)",start={Hmixg,Hliqg,Hvapg}) "Phase molar specific heat";
+  Real Cp_pc[3, Nc](each unit = "kJ/(kmol.K)") "Component molar specific heat in phase";
   Real H_p[3](each unit = "kJ/kmol",start={Hmixg,Hliqg,Hvapg}) "Phase molar enthalpy";
   Real H_pc[3, Nc](each unit = "kJ/kmol") "Component molar enthalpy in phase";
-  Real S_p[3](each unit = "kJ/[kmol.K]") "Phase molar entropy";
-  Real S_pc[3, Nc](each unit = "kJ/[kmol.K]") "Component molar entropy in phase";
+  Real S_p[3](each unit = "kJ/(kmol.K)") "Phase molar entropy";
+  Real S_pc[3, Nc](each unit = "kJ/(kmol.K)") "Component molar entropy in phase";
   Simulator.Files.Interfaces.matConn In(Nc = Nc) annotation(
     Placement(visible = true, transformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Simulator.Files.Interfaces.matConn Out(Nc = Nc) annotation(
@@ -148,4 +148,6 @@ annotation(
 </div><div><br></div><div>For variables which are decalared as 1-D array, the array size represent the phase where the array element indices 1 represents mixed phase, 2 represents liquid phase and 3 represents vapor phase.</div><div><br></div><div>For example, variable <b>F_p[3]</b> represents <i>Total molar flow in different phase</i>. So when simulated, the variables in the results will be as follow:</div><div>F_p[1] is Molar flow in mixed phase</div><div>F_p[2] is Molar flow in liquid phase</div><div>F_p[3] is Molar flow in vapor phase</div><div><br></div><div><br></div><div>For variables which are decalared as 2-D array, the first indice represent phase and second indice represents components.<div><br></div><div>For example, variable&nbsp;<b>F_pc[3,Nc]</b>&nbsp;represents <i>Component&nbsp;molar flow in different phase</i>. So when simulated, the variables in the results will be as follow:</div><div>F_pc[1,Nc] is Molar flow of Nc<sup>th</sup> in mixed phase</div><div>F_pc[2,Nc] is Molar flow of Nc<sup>th</sup> in liquid phase</div><div>F_pc[3,Nc] is Molar flow of Nc<sup>th</sup> in vapor phase</div></div><div><br></div><div><br></div><div>For examples on simulating a material stream, go to <b><i>Examples</i></b> &gt;&gt; <i><b>MaterialStream</b></i></div></body></html>"));
     
     end MaterialStream;
+
+
 

--- a/src/main/Simulator/Simulator/UnitOperations/AdiabaticCompressor.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/AdiabaticCompressor.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model AdiabaticCompressor "Model of an adiabatic compressor to provide energy to vapor stream in form of pressure"
   extends Simulator.Files.Icons.AdiabaticCompressor;
@@ -13,7 +13,7 @@ model AdiabaticCompressor "Model of an adiabatic compressor to provide energy to
   Real Tin(unit = "K", min = 0, start = Tg) "Inlet stream temperature";
   Real Hin(unit = "kJ/kmol",start=Htotg) "Inlet stream molar enthalpy";
   Real Sin(unit = "kJ/[kmol/K]") "Inlet stream molar entropy";
-  Real xvapin(unit = "-", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mol fraction";   
+  Real xvapin(unit = "1", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mol fraction";   
   
   Real Fout(min = 0, start = Fg) "Outlet stream molar flow rate";
   Real Q(unit = "W") "Power required";
@@ -23,11 +23,11 @@ model AdiabaticCompressor "Model of an adiabatic compressor to provide energy to
   Real Pout(unit = "Pa", min = 0, start = Pg) "Outlet stream pressure";
   Real Tout(unit = "Pa", min = 0, start = Tg) "Outlet stream temperature";
   Real Hout(unit = "kJ/kmol",start=Htotg) "Outlet stream molar enthalpy";
-  Real Sout(unit = "kJ/[kmol.K]") "Outlet stream molar entropy";
-  Real xvapout(unit = "-", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
-  Real x_c[Nc](each unit = "-", each min = 0, each max = 1,start=xg) "Component mole fraction";
+  Real Sout(unit = "kJ/(kmol.K)") "Outlet stream molar entropy";
+  Real xvapout(unit = "1", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
+  Real x_c[Nc](each unit = "1", each min = 0, each max = 1,start=xg) "Component mole fraction";
  
-  parameter Real Eff(unit = "-") "Efficiency";
+  parameter Real Eff(unit = "1") "Efficiency";
 
   //========================================================================================
   Files.Interfaces.matConn In(Nc = Nc) annotation(
@@ -76,3 +76,5 @@ equation
 annotation(
     Documentation(info = "<html><head></head><body><div style=\"font-size: 12px;\">Adiabatic Compressor is generally used to provide energy to a vapor material stream. The energy supplied is in form of pressure.</div><div style=\"font-size: 12px;\"><br></div><span style=\"font-size: 12px;\">To simulate an adiabatic compressor, Efficiency of the compressor should be provided as calculation parameter. Additionally, one of the following variables must be defined:</span><div style=\"font-size: 12px;\"><ol><li>Outlet Pressure</li><li>Pressure Increase</li><li>Power Required</li></ol><div><br></div></div><div style=\"font-size: 12px;\">For example on simulating an adiabatic compressor, go to&nbsp;<i><b>Examples</b></i>&nbsp;&gt;&gt; <b><i>Compressor</i></b></div></body></html>"));
     end AdiabaticCompressor;
+
+

--- a/src/main/Simulator/Simulator/UnitOperations/AdiabaticExpander.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/AdiabaticExpander.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model AdiabaticExpander "Model of an adiabatic expander to extract energy from a vapor stream in form of pressure"
   //=====================================================================================
@@ -7,15 +7,15 @@ model AdiabaticExpander "Model of an adiabatic expander to extract energy from a
   extends Simulator.Files.Models.Flash;
   parameter Simulator.Files.ChemsepDatabase.GeneralProperties C[Nc];
   parameter Integer Nc "Number of components";
-  parameter Real Eff(unit = "-") "Expander efficiency";
+  parameter Real Eff(unit = "1") "Expander efficiency";
   //====================================================================================
   //Model Variables
   Real Fin(unit = "mol/s", min = 0, start = Fg) "Inlet stream molar flow rate";
   Real Tin(unit = "K", min = 0, start = Tg) "Inlet stream temperature";
   Real Hin(unit = "kJ/kmol",start=Htotg) "Inlet stream molar enthalpy";
-  Real xvapin(unit = "-", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
-  Real xin_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Component mole fraction";
-  Real Sin(unit = "kJ/[kmol.K]") "Inlet stream molar entropy";
+  Real xvapin(unit = "1", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
+  Real xin_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Component mole fraction";
+  Real Sin(unit = "kJ/(kmol.K)") "Inlet stream molar entropy";
   Real Pin(unit = "Pa", min = 0, start = Pg) "Inlet stream pressure";
   Real Q(unit = "W") "Generated Power";
   Real Pdel(unit = "Pa") "Pressure drop";
@@ -24,8 +24,8 @@ model AdiabaticExpander "Model of an adiabatic expander to extract energy from a
   Real Fout(unit = "mol/s", min = 0, start = Fg) "Outlet stream molar flow rate";
   Real Tout(unit = "K", min = 0, start = Tg) "Outlet stream temperature";
   Real Hout(unit = "kJ/kmol") "Outlet stream molar enthalpy";
-  Real Sout(unit = "kJ/[kmol.k]") "Outlet stream molar entropy";
-  Real xvapout(unit = "-", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
+  Real Sout(unit = "kJ/(kmol.K)") "Outlet stream molar entropy";
+  Real xvapout(unit = "1", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
   //========================================================================================
   //Instantiation of connectors
   Files.Interfaces.matConn In(Nc = Nc) annotation(
@@ -73,3 +73,5 @@ equation
   annotation(
     Documentation(info = "<html><head></head><body><div style=\"font-size: 12px;\">Adiabatic Expander is generally used to extract energy from a vapor material stream. The energy extracted is in form of pressure.</div><div style=\"font-size: 12px;\"><br></div><span style=\"font-size: 12px;\">To simulate an adiabatic expander, Efficiency of the expander should be provided as calculation parameter. Additionally, one of the following variables must be defined:</span><div style=\"font-size: 12px;\"><ol><li>Outlet Pressure</li><li>Pressure Drop</li><li>Power Required</li></ol><div><br></div></div><div style=\"font-size: 12px;\">For example on simulating an adiabatic expander, go to&nbsp;<i><b>Examples</b></i>&nbsp;&gt;&gt;&nbsp;<b><i>Expander</i></b></div></body></html>"));
 end AdiabaticExpander;
+
+

--- a/src/main/Simulator/Simulator/UnitOperations/CentrifugalPump.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/CentrifugalPump.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model CentrifugalPump "Model of a centrifugal pump to provide energy to liquid stream in form of pressure"
   //===========================================================================
@@ -6,14 +6,14 @@ model CentrifugalPump "Model of a centrifugal pump to provide energy to liquid s
   extends Simulator.Files.Icons.CentrifugalPump;
   parameter Simulator.Files.ChemsepDatabase.GeneralProperties C[Nc];
   parameter Integer Nc = 2 "Number of components";
-  parameter Real Eff(unit = "-") "Efficiency";
+  parameter Real Eff(unit = "1") "Efficiency";
   //===========================================================================
   //Model Variables
   Real Pin(unit = "Pa", min = 0, start = Pg) "Inlet stream pressure";
   Real Tin(unit = "K", min = 0, start = Tg) "Inlet stream temperature";
   Real Hin(unit = "kJ/kmol",start=Htotg) "Inlet stream molar enthalpy";
   Real Fin(unit = "mol/s", min = 0, start = Fg) "Inlet stream molar flow";
-  Real xin_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Inlet stream components molar fraction";
+  Real xin_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Inlet stream components molar fraction";
   Real Tdel(unit = "K") "Temperature increase";
   Real Pdel(unit = "K") "Pressure increase";
   Real Q(unit = "W") "Power required";
@@ -25,7 +25,7 @@ model CentrifugalPump "Model of a centrifugal pump to provide energy to liquid s
   Real Tout(unit = "K", min = 0, start = Tg) "Outlet stream temperature";
   Real Hout(unit = "kJ/kmol",start=Htotg) "Outlet stream molar enthalpy";
   Real Fout(unit = "mol/s", min = 0, start = Fg) "Outlet stream molar flow";
-  Real xout_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Outlet stream molar fraction";
+  Real xout_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Outlet stream molar fraction";
   //============================================================================
   //Instantiation of Connectors
   Simulator.Files.Interfaces.matConn In(Nc = Nc) annotation(
@@ -74,3 +74,4 @@ equation
     Documentation(info = "<html><head></head><body><div>Centrifugal pump is generally used to provide energy to a liquid material stream. The energy supplied is in form of pressure.</div><div><br></div>To simulate a centrifugal pump, Efficiency of the pump should be provided as calculation parameter. Additional one of the following input variables must be defined:<div><ol><li>Outlet Pressure</li><li>Pressure Increase</li><li>Power Required</li></ol><div><br></div></div><div>For example on simulating a centrifual pum, go to <i><b>Examples</b></i> &gt;&gt; <i><b>Pump</b></i></div></body></html>"));
     
 end CentrifugalPump;
+

--- a/src/main/Simulator/Simulator/UnitOperations/Cooler.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/Cooler.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model Cooler "Model of a cooler to heat a material stream"
   extends Simulator.Files.Icons.Cooler; 
@@ -10,8 +10,8 @@ model Cooler "Model of a cooler to heat a material stream"
   Real Pin(unit = "Pa", min = 0, start =Pg) "Inlet stream pressure";
   Real Tin(unit = "K", min = 0, start = Tg) "Inlet stream temperature";
   Real Hin(unit = "kJ/kmol") "Inlet stream molar enthalpy";
-  Real Sin(unit = "kJ/[kmol.K]") "Inlet stream molar entropy";
-  Real xvapin(unit = "-", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
+  Real Sin(unit = "kJ/(kmol.K)") "Inlet stream molar entropy";
+  Real xvapin(unit = "1", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
   
   Real Q(unit = "W") "Heat removed";
   Real Tdel(unit = "K") "Temperature drop";
@@ -19,13 +19,13 @@ model Cooler "Model of a cooler to heat a material stream"
   Real Fout(unit = "mol/s", min = 0, start = Fg) "Outlet stream molar flow rate";
   Real Pout(unit = "Pa", min = 0, start = Pg) "Outlet stream pressure";
   Real Tout(unit = "K", min = 0, start = Tg) "Outlet stream temperature";
-  Real xvapout(unit = "-", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
+  Real xvapout(unit = "1", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
   Real Hout(unit = "kJ/kmol") "Outlet stream molar enthalpy";
-  Real Sout(unit = "kJ/[kmol.K]") "Outlet stream molar entropy"; 
-  Real x_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Component mole fraction";
+  Real Sout(unit = "kJ/(kmol.K)") "Outlet stream molar entropy"; 
+  Real x_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Component mole fraction";
   //========================================================================================
   parameter Real Pdel(unit = "Pa") "Pressure drop";
-  parameter Real Eff(unit = "-") "Efficiency";
+  parameter Real Eff(unit = "1") "Efficiency";
 
   //========================================================================================
   Files.Interfaces.matConn In(Nc = Nc) annotation(
@@ -68,3 +68,5 @@ annotation(
     Documentation(info = "<html><head></head><body><span style=\"font-size: 12px;\">The cooler is used to simulate the cooling process of a material stream.</span><div style=\"font-size: 12px;\"><br></div><div style=\"font-size: 12px;\">Following calculation parameters must be provided to the cooler:</div><div style=\"font-size: 12px;\"><ol><li>Pressure Drop</li><li>Efficiency</li></ol><div>In addition to the above parameters, any one additional variable from the below list must be provided for the model to simulate successfully:</div><div><ol><li>Outlet Temperature (Tout)</li><li>Temperature Drop (Tdel)</li><li>Heat Removed (Q)</li><li>Outlet Stream Vapor Phase Mole Fraction (xvapout)</li></ol><div><br></div></div><div>For example on simulating a cooler, go to <b><i>Examples</i></b> &gt;&gt; <i><b>Cooler</b></i></div></div></body></html>"));
     
     end Cooler;
+
+

--- a/src/main/Simulator/Simulator/UnitOperations/DistillationColumn/Cond.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/DistillationColumn/Cond.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations.DistillationColumn;
+﻿within Simulator.UnitOperations.DistillationColumn;
 
   model Cond "Model of a condenser used in distillation column"
     import Simulator.Files.*;
@@ -8,22 +8,22 @@ within Simulator.UnitOperations.DistillationColumn;
     Real P(unit = "K", min = 0, start = Pg) "Pressure";
     Real T(unit = "Pa", min = 0, start = Tg) "Temperature";
     Real Fin(unit = "mol/s", min = 0, start =Fg) "Feed molar flow rate";
-    Real xin_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Feed components mole fraction"; 
-    Real xvapin_c[Nc](each unit = "-", each min = 0, each max = 1, start=xvapg) "Inlet components vapor molar fraction"; 
+    Real xin_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Feed components mole fraction"; 
+    Real xvapin_c[Nc](each unit = "1", each min = 0, each max = 1, start=xvapg) "Inlet components vapor molar fraction"; 
     Real Hin(unit = "kJ/kmol",start=Htotg) "Feed inlet molar enthalpy";
    
     Real Fout(unit = "mol/s", min = 0, start = Fg) "Side draw molar flow";
     Real Fvapin(unit = "mol/s", min = 0, start = Fg) "Inlet vapor molar flow";
     Real Fliqout(unit = "mol/s", min = 0, start = Fg) "Outlet liquid molar flow";
-    Real xout_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Side draw components mole fraction";
-    Real xliqout_c[Nc](each unit = "-", each min = 0, each max = 1, start=xliqg) "Outlet components liquid mole fraction";
+    Real xout_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Side draw components mole fraction";
+    Real xliqout_c[Nc](each unit = "1", each min = 0, each max = 1, start=xliqg) "Outlet components liquid mole fraction";
     
     Real Hvapin(unit = "kJ/kmol",start=Hvapg) "Inlet vapor molar enthalpy";
     Real Hliqout(unit = "kJ/kmol",start=Hliqg) "Outlet liquid molar enthalpy";
     Real Q(unit = "W") "Heat load";
     Real Hout(unit = "kJ/kmol",start=Htotg) "Side draw molar enthalpy";
     Real Hliqout_c[Nc](each unit = "kJ/kmol") "Outlet liquid components molar enthalpy";
-    Real x_pc[3, Nc](each unit = "-", each min = 0, each max = 1,start={xguess,xguess,xguess}) "Component mole fraction";
+    Real x_pc[3, Nc](each unit = "1", each min = 0, each max = 1,start={xguess,xguess,xguess}) "Component mole fraction";
     Real Pdew(unit = "Pa", min = 0, start = Pmax) "Dew point pressure";
     Real Pbubl(unit = "Pa", min = 0,start=Pmin) "Bubble point pressure";
     
@@ -107,3 +107,4 @@ within Simulator.UnitOperations.DistillationColumn;
       Icon(coordinateSystem(extent = {{-100, -40}, {100, 40}})),
       __OpenModelica_commandLineOptions = "");
   end Cond;
+

--- a/src/main/Simulator/Simulator/UnitOperations/DistillationColumn/DistTray.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/DistillationColumn/DistTray.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations.DistillationColumn;
+﻿within Simulator.UnitOperations.DistillationColumn;
 
   model DistTray "Model of a tray used in distillation column"
     import Simulator.Files.*;
@@ -8,15 +8,15 @@ within Simulator.UnitOperations.DistillationColumn;
     Real P(unit = "Pa", min = 0, start = Pg) "Pressure";
     Real T(unit = "K", min = 0, start = Tg) "Temperature";
     Real Fin(unit = "mol/s", min = 0, start = Fg) "Feed molar flow";
-    Real xin_c[Nc](each unit = "-", each min = 0, each max = 1,start=xg) "Feed components mole fraction"; 
+    Real xin_c[Nc](each unit = "1", each min = 0, each max = 1,start=xg) "Feed components mole fraction"; 
     Real Hin(unit = "kJ/kmol",start=Htotg) "Feed molar enthalpy"; 
     
     Real Fout(unit = "mol/s", min = 0, start = Fg) "Sidedraw molar flow";
     Real Fvap_s[2](each unit = "mol/s", each min = 0,start={Fg,Fg}) "Vapor molar flow";
     Real Fliq_s[2](each unit = "mol/s", each min = 0,start={Fg,Fg}) "Liquid molar flow";  
-    Real xout_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Components mole fraction at sidedraw";
-    Real xvap_sc[2, Nc](each unit = "-", each min = 0, each max = 1, start=yg) "Components vapor mole fraction";
-    Real xliq_sc[2, Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Components liquid mole fraction";
+    Real xout_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Components mole fraction at sidedraw";
+    Real xvap_sc[2, Nc](each unit = "1", each min = 0, each max = 1, start=yg) "Components vapor mole fraction";
+    Real xliq_sc[2, Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Components liquid mole fraction";
  
     Real Hvap_s[2](unit = "kJ/kmol",start=Hvapg) "Vapor molar enthalpy";
     Real Hliq_s[2](unit = "kJ/kmol",start=Hliqg) "Liquid molar enthalpy";
@@ -135,3 +135,4 @@ within Simulator.UnitOperations.DistillationColumn;
       Icon(coordinateSystem(extent = {{-100, -40}, {100, 40}})),
       __OpenModelica_commandLineOptions = "");
   end DistTray;
+

--- a/src/main/Simulator/Simulator/UnitOperations/DistillationColumn/Reb.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/DistillationColumn/Reb.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations.DistillationColumn;
+﻿within Simulator.UnitOperations.DistillationColumn;
 
   model Reb "Model of a reboiler used in distillation column"
     import Simulator.Files.*;
@@ -10,19 +10,19 @@ within Simulator.UnitOperations.DistillationColumn;
     Real Fin(unit = "mol/s", min = 0, start = Fg) "Feed molar flow";
     Real Hin(unit = "kJ/kmol",start=Htotg) "Feed molar enthalpy";
     Real Hliqin(unit = "kJ/kmol",start=Hliqg) "Inlet liquid molar enthalpy";
-    Real xin_c[Nc](each unit = "-", each min = 0, each max = 1, start=xguess) "Feed components mole fraction"; 
+    Real xin_c[Nc](each unit = "1", each min = 0, each max = 1, start=xguess) "Feed components mole fraction"; 
     Real Fliqin(unit = "mol/s", min = 0, start =Fg) "Inlet liquid molar flow";
-    Real xliqin_c[Nc](each unit = "-", each min = 0, each max = 1,start=xg) "Inlet liquid component mole fraction";
+    Real xliqin_c[Nc](each unit = "1", each min = 0, each max = 1,start=xg) "Inlet liquid component mole fraction";
    
     Real Fout(unit = "mol/s", min = 0, start = Fg) "Side draw molar flow";
     Real Fvapout(unit = "mol/s", min = 0, start =Fvapg) "Outlet vapor molar flow";
-    Real xout_c[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Side draw mole fraction";
-    Real xvapout_c[Nc](each unit = "-", each min = 0, each max = 1, start=xvapg) "Outlet vapor component mole fraction";
+    Real xout_c[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Side draw mole fraction";
+    Real xvapout_c[Nc](each unit = "1", each min = 0, each max = 1, start=xvapg) "Outlet vapor component mole fraction";
     Real Hvapout(unit = "kJ/kmol",start=Hvapg) "Outlet vapor molar enthalpy";
     Real Hvapout_c[Nc](each unit = "kJ/kmol") "Outlet vapor component molar enthalpy";
     Real Q(unit = "W") "Heat load";
     Real Hout(unit = "kJ/kmol") "Side draw molar enthalpy";
-    Real x_pc[3, Nc](each unit = "-", each min = 0, each max = 1, each start = 1/(Nc + 1)) "Component mole fraction";
+    Real x_pc[3, Nc](each unit = "1", each min = 0, each max = 1, each start = 1/(Nc + 1)) "Component mole fraction";
     Real Pdew(unit = "Pa", min = 0, start = sum(C[:].Pc)/Nc) "Dew point pressure";
     Real Pbubl(unit = "Pa", min = 0, start = sum(C[:].Pc)/Nc) "Bubble point pressure";
    

--- a/src/main/Simulator/Simulator/UnitOperations/Flash.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/Flash.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model Flash "Model of a flash column to separate vapor and liquid phases from a mixed phase material stream"
 //==============================================================================
@@ -19,15 +19,15 @@ model Flash "Model of a flash column to separate vapor and liquid phases from a 
   Real Pbubl(unit = "Pa", min = 0, start = Pmin) "Bubble point pressure";
   Real Pdew(unit = "Pa", min = 0, start = Pmax) "Dew point pressure";
   Real F_p[3](each unit = "mol/s", each min = 0,start = {Fg,Fliqg,Fvapg})"Feed stream mole flow";
-  Real x_pc[3, Nc](each unit = "-", each min = 0, each max = 1, start={xguess,xg,yg}) "Component mole fraction";
-  Real Cp_pc[3, Nc](each unit = "kJ/[kmol.K]") "Component molar specific heat";
+  Real x_pc[3, Nc](each unit = "1", each min = 0, each max = 1, start={xguess,xg,yg}) "Component mole fraction";
+  Real Cp_pc[3, Nc](each unit = "kJ/(kmol.K)") "Component molar specific heat";
   Real H_pc[3, Nc](each unit = "kJ/kmol") "Comopent molar enthalpy";
-  Real S_pc[3, Nc](each unit = "kJ/[kmol.K]") "Component molar entropy";
-  Real Cp_p[3](each unit = "kJ/[kmol.K]") "Molar specific heat in phase";
+  Real S_pc[3, Nc](each unit = "kJ/(kmol.K)") "Component molar entropy";
+  Real Cp_p[3](each unit = "kJ/(kmol.K)") "Molar specific heat in phase";
   Real H_p[3](each unit = "kJ/kmol") "Molar enthalpy in phase";
-  Real S_p[3](each unit = "kJ/[kmol.K]") "Molar entropy in phase";
-  Real xliq(unit = "-", min = 0, max = 1, start = xliqg)"Liquid phase mole fraction";
-  Real xvap(unit = "-", min = 0, max = 1, start = xvapg) "Vapor phase mole fraction";
+  Real S_p[3](each unit = "kJ/(kmol.K)") "Molar entropy in phase";
+  Real xliq(unit = "1", min = 0, max = 1, start = xliqg)"Liquid phase mole fraction";
+  Real xvap(unit = "1", min = 0, max = 1, start = xvapg) "Vapor phase mole fraction";
   
 //===============================================================================
 //Instantiation of Connectors
@@ -127,3 +127,5 @@ annotation(
     __OpenModelica_commandLineOptions = "",
   Documentation(info = "<html><head></head><body>The flash column is used to calculate the vapor and liquid phase distribution for a mixed phase material stream.<div><br></div><div>Following calculation parameters may be provided for the flash column:</div><div><ol><li>Separation Temperature</li><li>Separation Pressure</li></ol><div><br></div></div><div>For example on simulating a flash column, go to <b><i>Examples</i></b> &gt;&gt; <b><i>Flash</i></b></div></body></html>"));
   end Flash;
+
+

--- a/src/main/Simulator/Simulator/UnitOperations/Heater.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/Heater.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model Heater "Model of a heater to heat a material stream"
   extends Simulator.Files.Icons.Heater;
@@ -10,19 +10,19 @@ model Heater "Model of a heater to heat a material stream"
   Real Pin(unit = "Pa", min = 0, start = Pg) "Inlet stream pressure";
   Real Tin(unit = "K", min = 0, start = Tg) "Inlet stream temperature";
   Real Hin(unit = "kJ/kmol",start=Htotg) "inlet stream molar enthalpy";
-  Real xvapin(unit = "-", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
+  Real xvapin(unit = "1", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
   
-  Real x_c[Nc](each unit = "-", each min = 0, each max = 1) "Component mole fraction";
+  Real x_c[Nc](each unit = "1", each min = 0, each max = 1) "Component mole fraction";
   Real Q(unit = "W") "Heat added";
   Real Fout(unit = "mol/s", min = 0, start = Fg) "outlet stream molar flow rate";
   Real Pout(unit = "Pa", min = 0, start = Pg) "Outlet stream pressure";
   Real Tout(unit = "K", min = 0, start = Tg) "Outlet stream temperature";
   Real Tdel(unit = "K") "Temperature Increase";
-  Real xvapout(unit = "-", min = 0, max = 1, start = xvapg) "Outlet stream vapor mole fraction";
+  Real xvapout(unit = "1", min = 0, max = 1, start = xvapg) "Outlet stream vapor mole fraction";
   Real Hout(unit = "kJ/kmol",start=Htotg) "outlet mixture molar enthalpy";
   //========================================================================================
   parameter Real Pdel(unit = "Pa") "Pressure drop";
-  parameter Real Eff(unit = "-") "Efficiency";
+  parameter Real Eff(unit = "1") "Efficiency";
   //========================================================================================
   Simulator.Files.Interfaces.matConn In(Nc = Nc) annotation(
     Placement(visible = true, transformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
@@ -60,3 +60,4 @@ equation
   annotation(
     Documentation(info = "<html><head></head><body>The heater is used to simulate the heating process of a material stream.<div><br></div><div>Following calculation parameters must be provided to the heater:</div><div><ol><li>Pressure Drop</li><li>Efficiency</li></ol><div>In addition to the above parameters, any one additional variable from the below list must be provided for the model to simulate successfully:</div><div><ol><li>Outlet Temperature (Tout)</li><li>Temperature Increase (Tdel)</li><li>Heat Added (Q)</li><li>Outlet Stream Vapor Phase Mole Fraction (xvapout)</li></ol><div><br></div></div><div><span style=\"font-size: 12px;\">For examples on simulating a heater, go to&nbsp;</span><b style=\"font-size: 12px;\"><i>Examples</i></b><span style=\"font-size: 12px;\">&nbsp;&gt;&gt; <b><i>Heater</i></b></span></div><div><br></div><div><br></div><div><br></div></div></body></html>"));
 end Heater;
+

--- a/src/main/Simulator/Simulator/UnitOperations/PFR/PFR.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/PFR/PFR.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations.PFR;
+﻿within Simulator.UnitOperations.PFR;
 
  model PFR         
   
@@ -26,10 +26,10 @@ within Simulator.UnitOperations.PFR;
         Real Pin(unit = "Pa", min = 0, start = Pg) "Inlet stream pressure";
         Real Fin_pc[3, Nc](each unit = "mol/s", each min = 0, start={Fg,Fliqg,Fvapg}) "Inlet stream components molar flow rate in phase";
         Real Fin_p[3](each unit = "mol/s", each min = 0,start={Fg,Fliqg,Fvapg}) "Inlet stream molar flow rate in phase";
-        Real xin_pc[3, Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Inlet stream mole fraction";
+        Real xin_pc[3, Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Inlet stream mole fraction";
         Real Hin(unit = "kJ/kmol",start=Htotg) "Inlet stream enthalpy";
-        Real Sin(unit = "kJ/[kmol.K]") "Inlet stream entropy";
-        Real xvapin(unit = "-", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
+        Real Sin(unit = "kJ/(kmol.K)") "Inlet stream entropy";
+        Real xvapin(unit = "1", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction";
         Real Cin_c[Nc] "Inlet Concentration";
         Real Fin_c[Nc](each min = 0, each start = Fg) "Inlet Mole Flow";
         
@@ -40,12 +40,12 @@ within Simulator.UnitOperations.PFR;
         Real Fout_pc[3, Nc](each unit = "mol/s", each min = 0, start={Fg,Fliqg,Fvapg}) "Outlet stream components molar flow rate";
         Real xout_pc[3, Nc](each min = 0,start=xg) "Mole Fraction of Component in outlet stream";
         Real Hout(unit = "kJ/kmol",start=Htotg) "Outlet stream molar enthalpy";
-        Real Sout(unit = "kJ/[kmol.K]") "Outlet stream molar entropy";
-        Real xvapout(unit = "-", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
+        Real Sout(unit = "kJ/(kmol.K)") "Outlet stream molar entropy";
+        Real xvapout(unit = "1", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
 
         Real MWout_p[3](each unit = "kg/kmol") "Outlset stream molecular weight in phase";
         Real Fmin_p[3](each unit = "kg/s",start={Fg,Fliqg,Fvapg}) "Inlet stream mass flow rate";
-        Real xm_pc[3, Nc](each unit = "-",start=xg) "Component mass fraction in phase";
+        Real xm_pc[3, Nc](each unit = "1",start=xg) "Component mass fraction in phase";
         Real MW_p[3](each unit = "kg/kmol")"Molecular weight of phase";
         Real Fv_p[3](start={Fg,Fliqg,Fvapg});
         
@@ -62,7 +62,7 @@ within Simulator.UnitOperations.PFR;
         Real k_r[Nr] "Rate constant";
         Real Hr(unit = "kJ/kmol") "Heat of Reaction";
         Real Fin_cr[Nc, Nr](each unit = "mol/s") "Number of moles at initial state";
-        Real X_r[Nc](each unit = "-", each min = 0, each max = 1, start=xg) "Conversion of the components in reaction";
+        Real X_r[Nc](each unit = "1", each min = 0, each max = 1, start=xg) "Conversion of the components in reaction";
         Real V(unit = "m3", min = 0) "Volume of the reactor";
         Real tr(unit = "s")"Residence Time";
         
@@ -430,3 +430,5 @@ for i in 1:Nc loop
       Diagram(coordinateSystem(extent = {{-350, -100}, {350, 100}})),
       __OpenModelica_Cin_cmmandLineOptions = "");
   end PFR;
+
+

--- a/src/main/Simulator/Simulator/UnitOperations/ShortcutColumn.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/ShortcutColumn.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model ShortcutColumn "Model of a shortcut column to calculate minimum reflux in a distillation column"
 
@@ -14,29 +14,29 @@ model ShortcutColumn "Model of a shortcut column to calculate minimum reflux in 
   //==============================================================================
   //Model Variables
   Real F_p[3](each unit = "mol/s", each min = 0, each start = Fg) "Inlet stream molar flow";
-  Real x_pc[3, Nc](each unit = "-",  start = {xguess,xg,yg}, each min = 0, each max = 1) "Inlet stream mole fraction";
+  Real x_pc[3, Nc](each unit = "1",  start = {xguess,xg,yg}, each min = 0, each max = 1) "Inlet stream mole fraction";
   Real H_p[3](each unit = "kJ/kmol",start={Htotg,Hliqg,Hvapg}) "Inlet stream molar enthalpy ";
-  Real S_p[3](each unit = "kJ/[kmol.K]") "Inlet stream molar entropy";
+  Real S_p[3](each unit = "kJ/(kmol.K)") "Inlet stream molar entropy";
   Real Pin(unit = "Pa", min = 0, start = Pg) "Inlet stream pressure";
   Real Tin(unit = "K", min = 0, start = Tg)"Inlet stream temperature";
-  Real xin_pc[3, Nc](each unit = "-", each min = 0, each max = 1, start={xguess,xg,yg}) "Inlet stream components mole fraction";
+  Real xin_pc[3, Nc](each unit = "1", each min = 0, each max = 1, start={xguess,xg,yg}) "Inlet stream components mole fraction";
   
-  Real Ntmin(unit = "-", min = 0, start = 10) "Minimum Number of trays";
-  Real RRmin(unit = "-", start = 1) "Minimum Reflux Ratio";
-  Real alpha_c[Nc](unit = "-") "Relative Volatility";
-  Real theta(unit = "-", start = 1) "Fraction";
+  Real Ntmin(unit = "1", min = 0, start = 10) "Minimum Number of trays";
+  Real RRmin(unit = "1", start = 1) "Minimum Reflux Ratio";
+  Real alpha_c[Nc](unit = "1") "Relative Volatility";
+  Real theta(unit = "1", start = 1) "Fraction";
   Real T(start=Tg) "Thermodynamic Adjustment", P(start=Pg) "Thermodynamic Adjustment";
   Real Tcond(unit = "K", start = max(C[:].Tb), min = 0)"Condenser temperature";
   Real Pcond(unit = "Pa", min = 0, start = 101325) "Condenser pressure";
   Real Preb(unit = "Pa", min = 0, start = 101325)"Reboiler pressure";
   Real Treb(unit = "K", start = min(C[:].Tb), min = 0) "Reboiler temperature";
-  Real xvap_p[3](each unit = "-", each min = 0, each max = 1, each start = xvapg) "Vapor Phase Mole Fraction";
+  Real xvap_p[3](each unit = "1", each min = 0, each max = 1, each start = xvapg) "Vapor Phase Mole Fraction";
   Real Hliqcond(unit = "kJ/kmol",start=Hliqg) "Enthalpy of liquid in condenser";
   Real Hvapcond(unit = "kJ/kmol",start=Hvapg) "Enthalpy of vapor in condenser";
   Real Hvapcond_c[Nc](each unit = "kJ/kmol") "Component enthalpy of vapor in condenser";
   Real Hliqcond_c[Nc](each unit = "kJ/kmol") "Component enthalpy of vapor in condenser";
-  Real xliqcond_c[Nc](each unit = "-", each min = 0, each max = 1,  start = xg)"Component mole fraction in liquid phase in condenser";
-  Real xvapcond_c[Nc](each unit = "-", each min = 0, each max = 1,  start = yg)"Component mole fraction in vapor phase in condenser";
+  Real xliqcond_c[Nc](each unit = "1", each min = 0, each max = 1,  start = xg)"Component mole fraction in liquid phase in condenser";
+  Real xvapcond_c[Nc](each unit = "1", each min = 0, each max = 1,  start = yg)"Component mole fraction in vapor phase in condenser";
   
   Real Pdew(unit = "Pa", min = 0, start = Pmax)"Dew point pressure";
   Real Pbubl(unit = "Pa", min = 0, start = Pmin)"Bubble point pressure";
@@ -220,3 +220,5 @@ annotation(
     __OpenModelica_commandLineOptions = "",
   Documentation(info = "<html><head></head><body><!--StartFragment--><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\">The shortcut column is used to calculate the minimum reflux in a distillation column by Fenske-Underwood-Gilliland (FUG) method.&nbsp;</span><div><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\"><br></span></div><div><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\">The column should have following inputs:</span></div><div><ol><li><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\">a single feed stage</span></li><li><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\">two products (top and bottom)</span></li><li><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\">condenser (total or partial)</span></li><li><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13.3333px; orphans: 2; widows: 2;\">reboiler</span></li></ol><div style=\"orphans: 2; widows: 2;\"><div><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">The results are:</span></font></div><div><ol><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Minumum Reflux Ratio</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Actual Reflux Ratio</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Total Number of Stages</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Feed Stage</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Condenser and Reboiler Duty</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Liquid and Vapor flows in Rectification and Stripping section</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Pressure and Temperature of Condenser and Reboiler</span></font></li></ol><div><br></div></div></div><div style=\"orphans: 2; widows: 2;\"><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">To simulate a shortcut column, following calculation parameters must be provided:</span></font></div><div style=\"orphans: 2; widows: 2;\"><ol><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Condenser Type</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">High Key Component</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Low Key Component</span></font></li></ol></div><div style=\"orphans: 2; widows: 2;\"><span style=\"font-family: Arial, Helvetica, sans-serif; font-size: 13px;\">Additionally, following input for following variables must be provided:</span></div><div style=\"orphans: 2; widows: 2;\"><ol><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Reflux Ratio</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Heavy Key Component Mole Fraction in Distillate</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Light Key Component Mole Fraction in Bottoms</span></font></li><li><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">Condenser and Reboiler Pressure</span></font></li></ol></div><div style=\"orphans: 2; widows: 2;\"><div><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\"><br></span></font></div><div><font face=\"Arial, Helvetica, sans-serif\"><span style=\"font-size: 13px;\">For example on simulating a Shortcut Column, go to <i><b>Examples</b></i> &gt;&gt; <i><b>ShortcutColumn</b></i></span></font></div></div><!--EndFragment--></div></body></html>"));
   end ShortcutColumn;
+
+

--- a/src/main/Simulator/Simulator/UnitOperations/Valve.mo
+++ b/src/main/Simulator/Simulator/UnitOperations/Valve.mo
@@ -1,4 +1,4 @@
-within Simulator.UnitOperations;
+﻿within Simulator.UnitOperations;
 
 model Valve "Model of a valve to regulate the pressure of a material stream"
   extends Simulator.Files.Icons.Valve;
@@ -9,8 +9,8 @@ model Valve "Model of a valve to regulate the pressure of a material stream"
   Real Pin(unit = "Pa", min = 0, start = Pg) "Inlet stream pressure"; 
   Real Tin(unit = "K", min = 0, start = Tg) "Inlet stream emperature";
   Real Hin(unit = "kJ/kmol",start=Htotg) "Inlet stream molar enthalpy"; 
-  Real Sin(unit = "kJ/[kmol.K]") "Inlet stream molar entropy";
-  Real xvapin(unit = "-", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction"; 
+  Real Sin(unit = "kJ/(kmol.K)") "Inlet stream molar entropy";
+  Real xvapin(unit = "1", min = 0, max = 1, start = xvapg) "Inlet stream vapor phase mole fraction"; 
   
   Real Tdel(unit = "K") "Temperature increase";
   Real Pdel(unit = "Pa") "Pressure drop"; 
@@ -19,9 +19,9 @@ model Valve "Model of a valve to regulate the pressure of a material stream"
   Real Pout(unit = "Pa", min = 0, start = Pg) "Outlet stream pressure";
   Real Tout(unit = "K", min = 0, start = Tg) "Outlet stream temperature";
   Real Hout(unit = "kJ/kmol",start=Htotg) "Outlet stream molar enthalpy";
-  Real Sout(unit = "kJ/[kmol.K]")  "Outlet stream molar entropy";
-  Real x_c[Nc](each unit = "-", each min = 0, each max = 1,  start = xg) "Component mole fraction";
-  Real xvapout(unit = "-", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
+  Real Sout(unit = "kJ/(kmol.K)")  "Outlet stream molar entropy";
+  Real x_c[Nc](each unit = "1", each min = 0, each max = 1,  start = xg) "Component mole fraction";
+  Real xvapout(unit = "1", min = 0, max = 1, start = xvapg) "Outlet stream vapor phase mole fraction";
   //========================================================================================
 
   //========================================================================================
@@ -61,3 +61,5 @@ annotation(
     Documentation(info = "<html><head></head><body><span style=\"font-size: 12px;\">The valve is used to simulate the pressure manipulation process of a material stream.</span><div style=\"font-size: 12px;\"><br></div><div style=\"font-size: 12px;\">To simulate a valve, one of the following calculation parameter must be provided:</div><div style=\"font-size: 12px;\"><div><ol><li>Outlet Pressure (Pout)</li><li>Pressure Drop (Pdel)</li></ol><div><br></div></div><div>For example on simulating a valve, go to&nbsp;<b><i>Examples</i></b>&nbsp;&gt;&gt; <b><i>Valve</i></b></div></div></body></html>"));
     
     end Valve;
+
+


### PR DESCRIPTION

This PR updates the semantic formatting of unit expressions across the package's `.mo` files to ensure strict compliance with the **Modelica 4.x standard**. These adjustments eliminate syntax errors and warnings triggered during rigorous unit checking in modern versions of the OpenModelica Compiler (OMC).


## Key Changes
### Modelica 4.x Semantic changes
- **Dimensionless Unit Update:** Replaced the invalid dimensionless marker `"-"` with the standard `"1"` across all unit attributes (e.g., mole fractions, parameters, ...).
- **Unit Expression Bracket Fix:** Converted unit expressions from using illegal square brackets like `[kmol.K]` to the standard parenthesis format `(kmol.K)` across all affected `.mo` files.