### PR TITLE
Fixed: OMC parse error (Expected RBRACE, got 'formate')

### DIFF
--- a/src/main/python/OMChem/Flowsheet.py
+++ b/src/main/python/OMChem/Flowsheet.py
@@ -327,8 +327,8 @@ class Flowsheet():
 
                 # --- Define compounds ---
                 for c in self.compounds:
-                    c_title = c.title()
-                    self.data.append(f"parameter Simulator.Files.Chemsep_Database.{c_title} {c_title};\n")
+                    norm = _normalize_compound_name(c)
+                    self.data.append(f"parameter Simulator.Files.Chemsep_Database.{norm} {norm};\n")
 
                 self.data.append(unitop.OM_Flowsheet_Initialize())
 

--- a/src/main/python/utils/UnitOperations.py
+++ b/src/main/python/utils/UnitOperations.py
@@ -5,7 +5,7 @@ parent = os.path.dirname(current)
 parentPath = os.path.dirname(parent)
 sys.path.append(parentPath)
 
-from python.OMChem.Flowsheet import Flowsheet
+from python.OMChem.Flowsheet import Flowsheet, _normalize_compound_name
 from python.OMChem.EngStm import EngStm
 from python.utils.ComponentSelector import *
 from python.utils.Container import *
@@ -138,8 +138,7 @@ class UnitOperation():
 
                     self.OM_data_init += self.for_naming[i] + str(self.counter) + ' ' + self.for_naming + '(Nc = ' + str(len(self.compounds))
                  
-            C = str(self.compounds).strip('[').strip(']')
-            C = C.replace("'", "")  
+            C = ', '.join(_normalize_compound_name(c) for c in self.compounds)
             self.OM_data_init += ',C = {' + C + '}'  
 
             for k in self.parameters:
@@ -153,8 +152,7 @@ class UnitOperation():
 
         else: 
             self.OM_data_init += 'Simulator.UnitOperations.' + self.type + ' ' + self.name + '(Nc = ' + str(len(self.compounds))
-            C = str(self.compounds).strip('[').strip(']')
-            C = C.replace("'", "")  
+            C = ', '.join(_normalize_compound_name(c) for c in self.compounds)
             self.OM_data_init += ',C = {' + C + '}'
 
             for k in self.parameters:
@@ -518,8 +516,7 @@ class CompoundSeparator(UnitOperation):
         self.OM_data_init = self.OM_data_init + (
         "Simulator.UnitOperations.CompoundSeparator " + self.name + "(Nc = " + str(comp_count))
         self.OM_data_init = self.OM_data_init + (", C = {")
-        comp = str(self.compounds).strip('[').strip(']')
-        comp = comp.replace("'", "")
+        comp = ', '.join(_normalize_compound_name(c) for c in self.compounds)
         self.OM_data_init = self.OM_data_init + comp + ("},")
         self.OM_data_init = self.OM_data_init + ("SepFact_c = " + SepFact + ",SepStrm = " + SepStrm + ");\n")
 


### PR DESCRIPTION

This PR resolves a critical OpenModelica (OMC) parsing error (`Expected RBRACE`) that occurred when simulating chemical compounds containing spaces, hyphens, or special characters. It enforces strict Modelica identifier compatibility by ensuring that all compound names are normalized into valid, single-word identifiers before being passed to the simulation engine.

### Changes
- **Function Integration:** Integrated the `_normalize_compound_name` utility function which was previously defined(Flowsheet.py ln 10-24) but was unused into the flowsheet generation logic. This function ensures that any multi-word or special-character compound name (e.g., `'Hydrogen cyanide'`, `'Carbon-tetrachloride'`) is programmatically transformed into a valid Modelica identifier (e.g., `'Hydrogencyanide'`, `'Carbontetrachloride'`) before compilation.
- **Improved String Handling:** Replaced fragile string stripping logic (`strip('[').strip(']')`) in `UnitOperations.py` with the `_normalize_compound_name` function. This prevents structural corruption of the string when handling lists of compounds.
